### PR TITLE
Binary mail body support

### DIFF
--- a/aiosmtplib/textutils.py
+++ b/aiosmtplib/textutils.py
@@ -73,7 +73,11 @@ def encode_message_string(message_str):
 
     Returns bytes.
     '''
-    message_bytes = message_str.encode('utf-8')
+    if isinstance(message_str, str):
+        message_bytes = message_str.encode('utf-8')
+    else:
+        assert isinstance(message_str, bytes)
+        message_bytes = message_str
     message_bytes = LINE_ENDINGS_REGEX.sub(b"\r\n", message_bytes)
     message_bytes = PERIOD_REGEX.sub(b'..', message_bytes)
     if not message_bytes.endswith(b"\r\n"):

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -154,6 +154,21 @@ async def test_sendmail_simple_success(smtp_client):
 
 
 @pytest.mark.asyncio
+async def test_sendmail_binary_content(smtp_client):
+    await smtp_client.connect()
+    test_address = 'test@example.com'
+    mail_text = b"""
+    Hello world!
+
+    -a tester
+    """
+    errors = await smtp_client.sendmail(
+        test_address, [test_address], mail_text)
+
+    assert errors is None
+
+
+@pytest.mark.asyncio
 async def test_sendmail_simple_failure(smtp_client):
     await smtp_client.connect()
     sender = 'test@example.com'


### PR DESCRIPTION
Sometimes you may want to send mail body already converted to bytes. For example when you work as a proxy with aiosmtpd with "decode_data = False", if you dont take care of message content you may want to send it as-is without unnecessary encode/decode which may unexpectedly fail if remote client doesn`t support utf-8, not RFC complaint or send body in unknown 8bit encoding.