### PR TITLE
Fix empty sender

### DIFF
--- a/aiosmtplib/smtp.py
+++ b/aiosmtplib/smtp.py
@@ -251,7 +251,7 @@ class SMTP(SMTPAuth):
 
         if sender is None:
             sender = extract_sender(message)
-        if not sender:
+        if sender is None:
             raise ValueError("No From header provided in message")
 
         if isinstance(recipients, str):


### PR DESCRIPTION
Sometimes I need to send EmailMessage without reply. 
```python
smtp = aiosmtplib.SMTP(...)
await smtp.connect()
await smtp.send_message(sender='', ...)
```

SMTP session:
```
MAIL FROM: <>
...
```

After this fix I can do it. Can you make small release for this?