### PR TITLE
tests/smtpd.py: Returns a permanent failure for unsupported auth mechanisms

### DIFF
--- a/tests/smtpd.py
+++ b/tests/smtpd.py
@@ -115,6 +115,8 @@ class TestSMTPD(SMTPD):
 
         if arg[:5] == "LOGIN":
             await self.smtp_AUTH_LOGIN(arg[6:])
+        else:
+            await self.push("504 Unsupported AUTH mechanism.")
 
     async def smtp_AUTH_LOGIN(self, arg):
         username = base64.b64decode(arg)


### PR DESCRIPTION
smtpd testing server does call a specific method when AUTH PLAIN is
used, but ignores without returning any other auth mechanism. As the
connector tries auth methods in a non-deterministic order, this leads to
a timeout if PLAIN is not the first mechanism tried.

This commit makes the smtpd test server return a permanent failure for
non-supported auth mechanisms.

Fixes issue #171