### PR TITLE
Fix __aexit__ annotations

### DIFF
--- a/aiosmtplib/connection.py
+++ b/aiosmtplib/connection.py
@@ -141,7 +141,7 @@ class SMTPConnection:
         return self
 
     async def __aexit__(
-        self, exc_type: Type[Exception], exc: Exception, traceback: Any
+        self, exc_type: Type[BaseException], exc: BaseException, traceback: Any
     ) -> None:
         if isinstance(exc, (ConnectionError, TimeoutError)):
             self.close()


### PR DESCRIPTION
`__aexit__` is supposed to accept any BaseException, not just Exception.