### PR TITLE
Do not overwrite client-level timeout from connect() and starttls()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.255'
+    rev: 'v0.0.257'
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.257'
+    rev: 'v0.0.259'
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/aiosmtplib/smtp.py
+++ b/aiosmtplib/smtp.py
@@ -65,9 +65,9 @@ class SMTP:
         ({}, 'OK')
 
     Keyword arguments can be provided either on :meth:`__init__` or when
-    calling the :meth:`connect` method. Note that in both cases these options
-    are saved for later use; subsequent calls to :meth:`connect` will use the
-    same options, unless new ones are provided.
+    calling the :meth:`connect` method. Note that, when provided on
+    :meth:`__init__`, these options are saved for later use; subsequent calls
+    to :meth:`connect` will use the same options, unless new ones are provided.
     """
 
     # Preferred methods first

--- a/aiosmtplib/smtp.py
+++ b/aiosmtplib/smtp.py
@@ -65,9 +65,11 @@ class SMTP:
         ({}, 'OK')
 
     Keyword arguments can be provided either on :meth:`__init__` or when
-    calling the :meth:`connect` method. Note that, when provided on
-    :meth:`__init__`, these options are saved for later use; subsequent calls
-    to :meth:`connect` will use the same options, unless new ones are provided.
+    calling the :meth:`connect` method. Note that in both cases these options,
+    except for ``timeout``, are saved for later use; subsequent calls to
+    :meth:`connect` will use the same options, unless new ones are provided.
+    ``timeout`` is saved for later use when provided on :meth:`__init__`, but
+    not when calling the :meth:`connect` method.
     """
 
     # Preferred methods first

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -190,9 +190,9 @@ Timeouts
 
 All commands accept a ``timeout`` keyword argument of a numerical value in
 seconds. This value is used for all socket operations, and will raise
-:exc:`.SMTPTimeoutError` if exceeded. Timeout values passed to :func:`send`,
-:meth:`SMTP.__init__` or :meth:`SMTP.connect` will be used as the default
-value for commands executed on the connection.
+:exc:`.SMTPTimeoutError` if exceeded. Timeout values passed to :func:`send` and
+:meth:`SMTP.__init__` will be used as the default value for commands executed
+on the connection.
 
 The default timeout is 60 seconds.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,7 +160,7 @@ async def test_connect_port_takes_precedence(
     await client.quit()
 
 
-async def test_connect_timeout_takes_precedence(
+async def test_connect_timeout_is_reverted(
     hostname: str,
     smtpd_server_port: int,
 ) -> None:
@@ -169,7 +169,7 @@ async def test_connect_timeout_takes_precedence(
     )
     await client.connect(timeout=0.99)
 
-    assert client.timeout == 0.99
+    assert client.timeout == 0.66
 
     await client.quit()
 


### PR DESCRIPTION
Changes SMTP.connect() and SMTP.starttls() to use passed timeout value locally without overriding client-level timeout. Allows specifying shorter timeout for initial connect routines and not affect the following operations that may require longer timeouts for data processing.
closes #207