### PR TITLE
Removed send HELLO befor QUIT

### DIFF
--- a/aiosmtplib/smtp.py
+++ b/aiosmtplib/smtp.py
@@ -794,9 +794,6 @@ class SMTP:
 
         :raises SMTPResponseException: on unexpected server response code
         """
-        # Can't quit without HELO/EHLO
-        await self._ehlo_or_helo_if_needed()
-
         response = await self.execute_command(b"QUIT", timeout=timeout)
         if response.code != SMTPStatus.closing:
             raise SMTPResponseException(response.code, response.message)


### PR DESCRIPTION
@cole hello! I don't know why library send `HELLO` before `QUIT`. 

For example: python std: https://github.com/python/cpython/blob/3.11/Lib/smtplib.py#L1002 - don't send. And I cannot find something about this in RFC. 

I think is better to don't send `HELLO` before `QUIT`.