### PR TITLE
Fix asyncio deadlock trying to reconnect after error

### DIFF
--- a/aiosmtplib/smtp.py
+++ b/aiosmtplib/smtp.py
@@ -425,12 +425,11 @@ class SMTP:
             response = await self._create_connection(
                 timeout=self.timeout if timeout is _default else timeout
             )
+            await self._maybe_start_tls_on_connect()
+            await self._maybe_login_on_connect()
         except Exception as exc:
             self.close()  # Reset our state to disconnected
             raise exc
-
-        await self._maybe_start_tls_on_connect()
-        await self._maybe_login_on_connect()
 
         return response
 


### PR DESCRIPTION
```python
try:
    response = await self._create_connection(
        timeout=self.timeout if timeout is _default else timeout
    )
except Exception as exc:
    self.close()  # Reset our state to disconnected
    raise exc
await self._maybe_start_tls_on_connect()
await self._maybe_login_on_connect()
return response
```
This is snippet from connect call, before it initializes asyncio.Lock and it is cleared only in close() method. Right now, if  _maybe_start_tls_on_connect or _maybe_login_on_connect raises an exception, lock will be held forever. Consequently, if you try to call connect method again, coroutine will be in deadlock until cancelled.

Current workaround is create subclass and override connect method to ensure lock is cleared
```python
class SMTPAdapter(SMTP):
    async def connect(self, *args: Any, **kwargs: Any) -> None:
        try:
            await super().connect(*args, **kwargs)
        except BaseException:
            self.close()
            raise
```