### PR TITLE
Run socket.getfqdn in loop executor

### DIFF
--- a/src/aiosmtplib/api.py
+++ b/src/aiosmtplib/api.py
@@ -61,7 +61,7 @@ async def send(
     :keyword password:  Password for login after connect.
     :keyword local_hostname: The hostname of the client.  If specified, used as the
         FQDN of the local host in the HELO/EHLO command. Otherwise, the result of
-        :func:`socket.getfqdn`. **Note that getfqdn will block the event loop.**
+        :func:`socket.getfqdn`.
     :keyword source_address: Takes a 2-tuple (host, port) for the socket to bind to
         as its source address before connecting. If the host is '' and port is 0,
         the OS default behavior will be used.


### PR DESCRIPTION
### Changes

-  `SMTP.local_hostname` is now a coroutine with a loop executor
- Added awaits for `SMTP.local_hostname()` in ehlo, helo and tests
- Removed note about loop lock in docstrings

### Notes

I made a naive implementation that repeats the logic of `asyncio.to_thread` from version 3.9. When support for version 3.8 is dropped, it can be simplified using `asyncio.to_thread`. I can make `import` depending on the version, but for such a simple case, this is probably unnecessary. 

closes #293 