### PR TITLE
refactor: protocol handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,10 @@ Changelog
 ------------------
 
 - **BREAKING**: Drop Python 3.8 support
-- Bugfix: Run `socket.getfqdn` in thread to avoid blocking event loop
-  if `local_hostname` not provided (thanks @Raidzin)
+- Feature: Added `SMTP.wait_closed` method to wait for the connection to close
+- Change: Refactored and updated protocol logic
+- Bugfix: Run `socket.getfqdn` in thread to avoid blocking event loop if
+  `local_hostname` not provided (thanks @Raidzin)
 
 3.0.2
 -----

--- a/src/aiosmtplib/protocol.py
+++ b/src/aiosmtplib/protocol.py
@@ -6,7 +6,8 @@ import asyncio
 import collections
 import re
 import ssl
-from typing import Any, Optional, cast
+import weakref
+from typing import Any, Callable, Optional, cast
 
 from .errors import (
     SMTPDataError,
@@ -140,35 +141,159 @@ class FlowControlMixin(asyncio.Protocol):
             self._drain_waiters.remove(waiter)
 
     def _get_close_waiter(
-        self, stream: Optional[asyncio.StreamWriter]
+        self, stream: Optional[asyncio.StreamReader]
     ) -> "asyncio.Future[None]":
         raise NotImplementedError
 
 
-class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
+class StreamReaderProtocol(FlowControlMixin, asyncio.Protocol):
+    """Helper class to adapt between Protocol and StreamReader.
+
+    (This is a helper class instead of making StreamReader itself a
+    Protocol subclass, because the StreamReader has other potential
+    uses, and to prevent the user of the StreamReader to accidentally
+    call inappropriate methods of the protocol.)
+
+    Copied from stdlib, with some simplifications.
+    """
+
+    def __init__(
+        self,
+        stream_reader: asyncio.StreamReader,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ):
+        super().__init__(loop=loop)
+
+        self._stream_reader_wr = weakref.ref(stream_reader)
+        self._transport: Optional[asyncio.Transport] = None
+        self._over_ssl = False
+        self._closed = self._loop.create_future()
+
+    @property
+    def _stream_reader(self):
+        if self._stream_reader_wr is None:
+            return None
+        return self._stream_reader_wr()
+
+    def _replace_transport(self, transport: asyncio.Transport) -> None:
+        self._transport = transport
+        self._over_ssl = transport.get_extra_info("sslcontext") is not None
+        self._stream_reader._transport = transport  # type: ignore
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        self._transport = cast(asyncio.Transport, transport)
+        reader = self._stream_reader
+        if reader is not None:
+            reader.set_transport(transport)
+        self._over_ssl = transport.get_extra_info("sslcontext") is not None
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        reader = self._stream_reader
+        if reader is not None:
+            if exc is None:
+                reader.feed_eof()
+            else:
+                reader.set_exception(exc)
+        if not self._closed.done():
+            if exc is None:
+                self._closed.set_result(None)
+            else:
+                self._closed.set_exception(exc)
+
+        super().connection_lost(exc)
+
+        self._stream_reader_wr = None
+        self._transport = None
+
+    def data_received(self, data: bytes) -> None:
+        reader = self._stream_reader
+        if reader is not None:
+            reader.feed_data(data)
+
+    def eof_received(self):
+        reader = self._stream_reader
+        if reader is not None:
+            reader.feed_eof()
+        if self._over_ssl:
+            # Prevent a warning in SSLProtocol.eof_received:
+            # "returning true from eof_received()
+            # has no effect when using ssl"
+            return False
+        return True
+
+    def _get_close_waiter(
+        self, stream: Optional[asyncio.StreamReader]
+    ) -> "asyncio.Future[None]":
+        return self._closed
+
+    def __del__(self):
+        # Prevent reports about unhandled exceptions.
+        # Better than self._closed._log_traceback = False hack
+        try:
+            closed = self._closed
+        except AttributeError:
+            pass  # failed constructor
+        else:
+            if closed.done() and not closed.cancelled():
+                closed.exception()
+
+
+class SMTPStreamWriter(asyncio.StreamWriter):
+    """A StreamWriter subclass for SMTP connections.
+
+    Adds our own `start_tls` method, which is used to upgrade the connection on older
+    Python versions.
+    """
+
+    _loop: asyncio.AbstractEventLoop
+    _protocol: "SMTPProtocol"
+
+    async def start_tls(
+        self,
+        sslcontext: ssl.SSLContext,
+        *,
+        server_hostname: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Upgrade an existing stream-based connection to TLS."""
+        protocol = self._protocol
+        await self.drain()
+        new_transport = await self._loop.start_tls(
+            self._transport,  # type: ignore
+            protocol,
+            sslcontext,
+            server_side=False,
+            server_hostname=server_hostname,
+            **kwargs,
+        )
+        self._transport = new_transport
+        protocol._replace_transport(new_transport)  # type: ignore
+
+
+class SMTPProtocol(StreamReaderProtocol):
     def __init__(
         self,
         loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
-        super().__init__(loop=loop)
-        self._over_ssl = False
-        self._buffer = bytearray()
-        self._response: Optional[SMTPResponse] = None
-        self._response_waiter: Optional[asyncio.Future[None]] = None
-        self._exception: Optional[Exception] = None
-        self._closed: "asyncio.Future[None]" = self._loop.create_future()
-        self._transport: Optional[asyncio.Transport] = None
+        reader = asyncio.StreamReader(limit=MAX_LINE_LENGTH, loop=loop)
+
+        super().__init__(reader, loop=loop)
+
+        self._reader = reader
+        self._writer = None
 
         self._command_lock: Optional[asyncio.Lock] = None
-        self._quit_sent = False
-
-    # Core state methods. These are called in order of:
-    # connection_made -> data_received* -> eof_received? -> connection_lost
+        self._quit_sent: Optional[bool] = None
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
-        self._transport = cast(asyncio.Transport, transport)
-        self._over_ssl = transport.get_extra_info("sslcontext") is not None
-        self._response_waiter = self._loop.create_future()
+        super().connection_made(transport)
+        self._writer = SMTPStreamWriter(
+            cast(asyncio.Transport, transport),
+            self,
+            self._stream_reader,
+            loop=self._loop,
+        )
+
         self._command_lock = asyncio.Lock()
         self._quit_sent = False
 
@@ -179,116 +304,54 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
             if exc:
                 smtp_exc.__cause__ = exc
 
-        if smtp_exc and not self._quit_sent:
-            self._set_exception(smtp_exc)
+        super().connection_lost(smtp_exc)
 
-        if self._closed and not self._closed.done():
-            if smtp_exc is None:
-                self._closed.set_result(None)
-            else:
-                self._closed.set_exception(smtp_exc)
-
-        super().connection_lost(exc)
-
+        command_lock = self._command_lock
         self._command_lock = None
+        if command_lock is not None and command_lock.locked():
+            command_lock.release()
+
+        if self._writer:
+            self._writer.close()
+        self._writer = None
         self._transport = None
 
-    def data_received(self, data: bytes) -> None:
-        self._buffer.extend(data)
+    def eof_received(self):
+        super().eof_received()
 
-        # If we got an obvious partial message, don't try to parse the buffer
-        last_linebreak = data.rfind(b"\n")
-        if (
-            last_linebreak == -1
-            or data[last_linebreak + 3 : last_linebreak + 4] == b"-"
-        ):
-            return
-
-        try:
-            response = read_response_from_buffer(self._buffer)
-        except Exception as exc:
-            self._set_exception(exc)
-        else:
-            if response is not None:
-                self._set_response(response)
-
-    def eof_received(self) -> bool:
-        self._set_exception(SMTPServerDisconnected("Unexpected EOF received"))
-
-        # Returning false closes the transport
+        # Close the connection
         return False
-
-    # Transport wrappers
 
     def get_transport_info(self, key: str) -> Any:
         if self._transport is None:
             return None
         return self._transport.get_extra_info(key)
 
-    def set_transport(self, transport: asyncio.Transport) -> None:
-        if self._transport is not None:
-            raise RuntimeError("Transport already set")
-        self._transport = transport
-
     def _replace_transport(self, transport: asyncio.Transport) -> None:
-        self._transport = transport
-        self._over_ssl = transport.get_extra_info("sslcontext") is not None
+        super()._replace_transport(transport)
+        self._writer._transport = transport  # type: ignore
 
-    def close(self) -> None:
-        if self._transport is not None:
-            self._transport.close()
+    def close(self, callback: Optional[Callable[[asyncio.Future[None]], Any]]) -> None:
+        if self._writer is not None:
+            self._writer.close()
 
-    def is_closing(self) -> bool:
-        return bool(self._transport and self._transport.is_closing())
-
-    # Helper methods similar to those on asyncio.StreamWriter/StreamReader
-
-    def _get_close_waiter(
-        self, stream: Optional[asyncio.StreamWriter]
-    ) -> "asyncio.Future[None]":
-        return self._closed
-
-    def __del__(self) -> None:
-        # Avoid 'Future exception was never retrieved' warnings
-        try:
-            closed = self._closed
-        except AttributeError:
-            pass  # failed constructor
-        else:
-            if closed.done() and not closed.cancelled():
-                closed.exception()
+        if callback:
+            self._get_close_waiter(None).add_done_callback(callback)
 
     async def wait_closed(self) -> None:
+        if self._writer is not None:
+            await self._writer.wait_closed()
         await self._get_close_waiter(None)
 
-    def _set_exception(self, exc: Exception) -> None:
-        self._exception = exc
-
-        waiter = self._response_waiter
-        if waiter is not None:
-            self._response_waiter = None
-            if not waiter.cancelled():
-                waiter.set_exception(exc)
-
-    def _set_response(self, response: Optional[SMTPResponse]) -> None:
-        self._response = response
-        self._wakeup_waiter()
-
-    def _wakeup_waiter(self) -> None:
-        waiter = self._response_waiter
-        if waiter is not None:
-            self._response_waiter = None
-            if not waiter.cancelled():
-                waiter.set_result(None)
-
-    # SMTP specific methods
+    def is_closing(self) -> bool:
+        return self._transport is None or self._transport.is_closing()
 
     @property
     def is_connected(self) -> bool:
         """
         Check if our transport is still connected.
         """
-        return bool(self._transport is not None and not self.is_closing())
+        return not self.is_closing()
 
     async def read_response(self) -> SMTPResponse:
         """
@@ -302,66 +365,61 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
           - server response string (multiline responses are converted to a
             single, multiline string).
         """
-        if self._response_waiter is None:
-            raise SMTPServerDisconnected("Connection lost")
 
-        try:
-            await self._response_waiter
-        except asyncio.CancelledError as exc:
-            raise SMTPTimeoutError("Timed out while waiting for response") from exc
-        response = self._response
-        self._response = None
+        buffer = bytearray()
 
-        # If we were disconnected, don't create a new waiter
-        if self._transport is None or self.is_closing():
-            self._response_waiter = None
-        else:
-            self._response_waiter = self._loop.create_future()
+        response = None
+        while response is None:
+            try:
+                data = await self._reader.readuntil(b"\n")
+            except asyncio.IncompleteReadError as exc:
+                buffer.extend(exc.partial)
+            else:
+                buffer.extend(data)
 
-        if response is None:
-            raise RuntimeError("Invalid state: missing response")
+            response = read_response_from_buffer(buffer)
 
-        return response
+            if response:
+                return response
 
-    def write(self, data: bytes) -> None:
-        if self._transport is None or self.is_closing():
-            raise SMTPServerDisconnected("Connection lost")
+            if self.is_closing() or self._reader.at_eof():
+                raise SMTPServerDisconnected("Server disconnected")
 
-        try:
-            cast(asyncio.WriteTransport, self._transport).write(data)
-        # uvloop raises NotImplementedError, asyncio doesn't have a write method
-        except (AttributeError, NotImplementedError):
-            raise RuntimeError(
-                f"Transport {self._transport!r} does not support writing."
-            ) from None
+        raise RuntimeError("No response from server")
 
-    async def execute_command(
-        self, *args: bytes, timeout: Optional[float] = None, quit: bool = False
-    ) -> SMTPResponse:
+    async def write(self, data: bytes) -> None:
+        if self._writer is None:
+            raise RuntimeError("Writer not initialized")
+
+        self._writer.write(data)
+        await self._writer.drain()
+
+    async def execute_command(self, *args: bytes, quit: bool = False) -> SMTPResponse:
         """
         Sends an SMTP command along with any args to the server, and returns
         a response.
         """
+        if self._writer is None or self._writer.is_closing():
+            raise SMTPServerDisconnected("Connection lost")
         if self._command_lock is None:
-            raise SMTPServerDisconnected("Server not connected")
+            raise RuntimeError("Command lock not initialized")
+
         command = b" ".join(args) + b"\r\n"
 
         async with self._command_lock:
-            self.write(command)
+            try:
+                await self.write(command)
+            except ConnectionResetError as exc:
+                raise SMTPServerDisconnected("Connection lost") from exc
 
             if quit:
                 self._quit_sent = True
 
-            try:
-                response = await asyncio.wait_for(self.read_response(), timeout)
-            except asyncio.TimeoutError as exc:
-                raise SMTPTimeoutError("Timed out while waiting for response") from exc
+            response = await self.read_response()
 
         return response
 
-    async def execute_data_command(
-        self, message: bytes, timeout: Optional[float] = None
-    ) -> SMTPResponse:
+    async def execute_data_command(self, message: bytes) -> SMTPResponse:
         """
         Sends an SMTP DATA command to the server, followed by encoded message content.
 
@@ -369,25 +427,23 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
         Lone \\\\r and \\\\n characters are converted to \\\\r\\\\n
         characters.
         """
+        if self._writer is None or self._writer.is_closing():
+            raise SMTPServerDisconnected("Connection lost")
         if self._command_lock is None:
-            raise SMTPServerDisconnected("Server not connected")
+            raise RuntimeError("Command lock not initialized")
 
         formatted_message = format_data_message(message)
 
         async with self._command_lock:
-            self.write(b"DATA\r\n")
-            try:
-                start_response = await asyncio.wait_for(self.read_response(), timeout)
-            except asyncio.TimeoutError as exc:
-                raise SMTPTimeoutError("Timed out while waiting for response") from exc
+            await self.write(b"DATA\r\n")
+
+            start_response = await self.read_response()
             if start_response.code != SMTPStatus.start_input:
                 raise SMTPDataError(start_response.code, start_response.message)
 
-            self.write(formatted_message)
-            try:
-                response = await asyncio.wait_for(self.read_response(), timeout)
-            except asyncio.TimeoutError as exc:
-                raise SMTPTimeoutError("Timed out while waiting for response") from exc
+            await self.write(formatted_message)
+
+            response = await self.read_response()
             if response.code != SMTPStatus.completed:
                 raise SMTPDataError(response.code, response.message)
 
@@ -402,30 +458,26 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
         """
         Puts the connection to the SMTP server into TLS mode.
         """
+        if self._writer is None or self._writer.is_closing():
+            raise SMTPServerDisconnected("Connection lost")
         if self._over_ssl:
-            raise RuntimeError("Already using TLS.")
-        if self._transport is None or self._command_lock is None:
-            raise SMTPServerDisconnected("Server not connected")
+            raise RuntimeError("Already using TLS")
+        if self._command_lock is None:
+            raise RuntimeError("Command lock not initialized")
 
         async with self._command_lock:
-            self.write(b"STARTTLS\r\n")
-            try:
-                response = await asyncio.wait_for(self.read_response(), timeout)
-            except asyncio.TimeoutError as exc:
-                raise SMTPTimeoutError("Timed out while waiting for response") from exc
+            await self.write(b"STARTTLS\r\n")
+            response = await self.read_response()
             if response.code != SMTPStatus.ready:
                 raise SMTPResponseException(response.code, response.message)
 
             # Check for disconnect after response
-            if self.is_closing():
+            if self._writer.is_closing():
                 raise SMTPServerDisconnected("Connection lost")
 
             try:
-                tls_transport = await self._loop.start_tls(
-                    cast(asyncio.WriteTransport, self._transport),
-                    self,
+                await self._writer.start_tls(
                     tls_context,
-                    server_side=False,
                     server_hostname=server_hostname,
                     ssl_handshake_timeout=timeout,
                 )
@@ -440,10 +492,5 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
                 raise SMTPServerDisconnected(
                     "Connection reset while upgrading transport"
                 ) from exc
-
-            if tls_transport is None:
-                raise SMTPServerDisconnected("Failed to upgrade transport")
-
-            self._replace_transport(tls_transport)
 
         return response

--- a/src/aiosmtplib/protocol.py
+++ b/src/aiosmtplib/protocol.py
@@ -226,7 +226,8 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
         return self._transport.get_extra_info(key)
 
     def set_transport(self, transport: asyncio.Transport) -> None:
-        assert self._transport is None, "Transport already set"
+        if self._transport is not None:
+            raise RuntimeError("Transport already set")
         self._transport = transport
 
     def _replace_transport(self, transport: asyncio.Transport) -> None:

--- a/src/aiosmtplib/smtp.py
+++ b/src/aiosmtplib/smtp.py
@@ -141,7 +141,6 @@ class SMTP:
         :raises ValueError: mutually exclusive options provided
         """
         self.protocol: Optional[SMTPProtocol] = None
-        self.transport: Optional[asyncio.BaseTransport] = None
 
         # Kwarg defaults are provided here, and saved for connect.
         self.hostname = hostname
@@ -179,16 +178,20 @@ class SMTP:
         return self
 
     async def __aexit__(
-        self, exc_type: type[BaseException], exc: BaseException, traceback: Any
+        self,
+        exc_type: type[BaseException],
+        exc: Optional[BaseException],
+        traceback: Any,
     ) -> None:
         if isinstance(exc, (ConnectionError, TimeoutError)):
             self.close()
             return
 
-        try:
-            await self.quit()
-        except (SMTPServerDisconnected, SMTPResponseException, SMTPTimeoutError):
-            pass
+        if self.protocol is not None:
+            try:
+                await self.quit()
+            except (SMTPServerDisconnected, SMTPResponseException, SMTPTimeoutError):
+                pass
 
     @property
     def is_connected(self) -> bool:
@@ -443,7 +446,8 @@ class SMTP:
             await self._maybe_start_tls_on_connect()
             await self._maybe_login_on_connect()
         except Exception as exc:
-            self.close()  # Reset our state to disconnected
+            # Reset our state to disconnected
+            self.close()
             raise exc
 
         return response
@@ -490,7 +494,7 @@ class SMTP:
             )
 
         try:
-            transport, _ = await asyncio.wait_for(connect_coro, timeout=timeout)
+            await asyncio.wait_for(connect_coro, timeout=timeout)
         except (TimeoutError, asyncio.TimeoutError) as exc:
             raise SMTPConnectTimeoutError(
                 f"Timed out connecting to {self.hostname} on port {self.port}"
@@ -501,10 +505,9 @@ class SMTP:
             ) from exc
 
         self.protocol = protocol
-        self.transport = transport
 
         try:
-            response = await protocol.read_response(timeout=timeout)
+            response = await asyncio.wait_for(protocol.read_response(), timeout)
         except SMTPServerDisconnected as exc:
             raise SMTPConnectError(
                 f"Error connecting to {self.hostname} on port {self.port}: {exc}"
@@ -595,17 +598,23 @@ class SMTP:
         """
         Closes the connection.
         """
-        if self.transport is not None and not self.transport.is_closing():
-            self.transport.close()
+        if self.protocol is not None and not self.protocol.is_closing():
+            self.protocol.close()
 
         if self._connect_lock is not None and self._connect_lock.locked():
             self._connect_lock.release()
 
-        self.protocol = None
-        self.transport = None
-
         # Reset ESMTP state
         self._reset_server_state()
+
+    async def wait_closed(self) -> None:
+        """
+        Wait for the connection to close.
+        """
+        if self.protocol is not None:
+            await self.protocol.wait_closed()
+
+            self.protocol = None
 
     def get_transport_info(self, key: str) -> Any:
         """
@@ -623,10 +632,10 @@ class SMTP:
 
         :raises SMTPServerDisconnected: connection lost
         """
-        if not (self.is_connected and self.transport):
+        if not (self.is_connected and self.protocol):
             raise SMTPServerDisconnected("Server not connected")
 
-        return self.transport.get_extra_info(key)
+        return self.protocol.get_transport_info(key)
 
     # Base SMTP commands #
 
@@ -799,11 +808,20 @@ class SMTP:
 
         :raises SMTPResponseException: on unexpected server response code
         """
-        response = await self.execute_command(b"QUIT", timeout=timeout)
+
+        if self.protocol is None:
+            raise SMTPServerDisconnected("Server not connected")
+
+        timeout = self.timeout if timeout is Default.token else timeout
+        response = await self.protocol.execute_command(
+            b"QUIT", timeout=timeout, quit=True
+        )
         if response.code != SMTPStatus.closing:
             raise SMTPResponseException(response.code, response.message)
 
         self.close()
+
+        await self.wait_closed()
 
         return response
 
@@ -1027,9 +1045,6 @@ class SMTP:
         response = await self.protocol.start_tls(
             tls_context, server_hostname=server_hostname, timeout=timeout
         )
-
-        # Update our transport reference
-        self.transport = self.protocol.transport
 
         # RFC 3207 part 4.2:
         # The client MUST discard any knowledge obtained from the server, such

--- a/tests/smtpd.py
+++ b/tests/smtpd.py
@@ -144,7 +144,6 @@ async def mock_response_done_then_close(
     if args and args[0]:
         smtpd.session.host_name = args[0]
     await smtpd.push("250 done")
-    await smtpd.push("221 bye now")
     smtpd.transport.close()
 
 

--- a/tests/smtpd.py
+++ b/tests/smtpd.py
@@ -104,14 +104,32 @@ class TestSMTPD(SMTPD):
         self.event_handler.record_command("STARTTLS", arg)
 
 
-async def mock_response_delayed_ok(smtpd: SMTPD, *args: Any, **kwargs: Any) -> None:
+async def mock_response_delayed_ok_with_cleanup(
+    smtpd: SMTPD, *args: Any, **kwargs: Any
+) -> None:
     await asyncio.sleep(1.0)
     await smtpd.push("250 all done")
 
+    if smtpd._handler_coroutine:
+        handler = smtpd._handler_coroutine
+        handler.cancel()
+        await handler
+    if smtpd.transport:
+        smtpd.transport.close()
 
-async def mock_response_delayed_read(smtpd: SMTPD, *args: Any, **kwargs: Any) -> None:
+
+async def mock_response_delayed_read_with_cleanup(
+    smtpd: SMTPD, *args: Any, **kwargs: Any
+) -> None:
     await smtpd.push("220-hi")
     await asyncio.sleep(1.0)
+
+    if smtpd._handler_coroutine:
+        handler = smtpd._handler_coroutine
+        handler.cancel()
+        await handler
+    if smtpd.transport:
+        smtpd.transport.close()
 
 
 async def mock_response_done(smtpd: SMTPD, *args: Any, **kwargs: Any) -> None:
@@ -239,6 +257,8 @@ async def mock_response_syntax_error_and_cleanup(
     await smtpd.push(f"{SMTPStatus.syntax_error} error")
 
     if smtpd._handler_coroutine:
-        smtpd._handler_coroutine.cancel()
+        handler = smtpd._handler_coroutine
+        handler.cancel()
+        await handler
     if smtpd.transport:
         smtpd.transport.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,6 +26,7 @@ async def test_send(
         hostname=hostname,
         port=smtpd_server_port,
         tls_context=client_tls_context,
+        timeout=1.0,
     )
 
     assert not errors
@@ -47,6 +48,7 @@ async def test_send_with_str(
         sender=sender_str,
         recipients=[recipient_str],
         start_tls=False,
+        timeout=1.0,
     )
 
     assert not errors
@@ -68,6 +70,7 @@ async def test_send_with_bytes(
         sender=sender_str,
         recipients=[recipient_str],
         start_tls=False,
+        timeout=1.0,
     )
 
     assert not errors
@@ -107,6 +110,7 @@ async def test_send_without_recipients(
             sender=sender_str,
             recipients=[],
             start_tls=False,
+            timeout=1.0,
         )
 
 
@@ -124,6 +128,7 @@ async def test_send_with_start_tls(
         port=smtpd_server_port,
         start_tls=True,
         tls_context=client_tls_context,
+        timeout=1.0,
     )
 
     assert not errors
@@ -149,6 +154,7 @@ async def test_send_with_login(
         tls_context=client_tls_context,
         username=auth_username,
         password=auth_password,
+        timeout=1.0,
     )
 
     assert not errors
@@ -171,6 +177,7 @@ async def test_send_via_socket(
             port=None,
             sock=sock,
             start_tls=False,
+            timeout=1.0,
         )
 
         assert not errors
@@ -189,6 +196,7 @@ async def test_send_via_socket_path(
         port=None,
         socket_path=socket_path,
         start_tls=False,
+        timeout=1.0,
     )
 
     assert not errors
@@ -211,6 +219,7 @@ async def test_send_with_mail_options(
         recipients=[recipient_str],
         mail_options=["BODY=8BITMIME"],
         start_tls=False,
+        timeout=1.0,
     )
 
     assert not errors
@@ -234,6 +243,7 @@ async def test_send_with_rcpt_options(
         # RCPT params are not supported by the server; just check that the kwarg works
         rcpt_options=[],
         start_tls=False,
+        timeout=1.0,
     )
 
     assert not errors

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -176,8 +176,6 @@ async def test_send_via_socket(
         assert not errors
         assert len(received_messages) == 1
 
-        assert sock.fileno() > 0, "Socket unexpectedly closed"
-
 
 async def test_send_via_socket_path(
     smtpd_server_socket_path: asyncio.AbstractServer,

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -177,7 +177,7 @@ async def test_close_works_on_stopped_loop(
 
     await client.connect()
     assert client.is_connected
-    assert client.transport is not None
+    assert client.protocol is not None
 
     event_loop.stop()
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -47,9 +47,7 @@ async def test_plain_smtp_connect(
     assert not smtp_client.is_connected
 
 
-async def test_quit_then_connect_ok(
-    smtp_client: SMTP, smtpd_server: asyncio.AbstractServer
-) -> None:
+async def test_quit_then_connect_ok(smtp_client: SMTP) -> None:
     async with smtp_client:
         response = await smtp_client.quit()
         assert response.code == SMTPStatus.closing
@@ -114,7 +112,7 @@ async def test_connect_error_with_no_server(
 async def test_disconnected_server_raises_on_client_read(smtp_client: SMTP) -> None:
     await smtp_client.connect()
 
-    with pytest.raises(SMTPServerDisconnected):
+    with pytest.raises(SMTPServerDisconnected, match="Server disconnected"):
         await smtp_client.execute_command(b"NOOP")
 
     assert not smtp_client.is_connected

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -10,7 +10,7 @@ import ssl
 
 import pytest
 
-from aiosmtplib import SMTPResponseException, SMTPServerDisconnected, SMTPTimeoutError
+from aiosmtplib import SMTPResponseException, SMTPServerDisconnected
 from aiosmtplib.protocol import FlowControlMixin, SMTPProtocol
 
 from .compat import cleanup_server
@@ -61,23 +61,13 @@ async def test_protocol_read_limit_overrun(
     monkeypatch.setattr("aiosmtplib.protocol.MAX_LINE_LENGTH", 128)
 
     with pytest.raises(SMTPResponseException) as exc_info:
-        await protocol.execute_command(b"TEST\n", timeout=1.0)  # type: ignore
+        await protocol.execute_command(b"TEST\n")
 
     assert exc_info.value.code == 500
     assert "Response too long" in exc_info.value.message
 
     server.close()
     await cleanup_server(server)
-
-
-async def test_protocol_connected_check_on_read_response(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    protocol = SMTPProtocol()
-    monkeypatch.setattr(protocol, "_transport", None)
-
-    with pytest.raises(SMTPServerDisconnected):
-        await protocol.read_response()
 
 
 async def test_protocol_read_only_transport_error() -> None:
@@ -89,8 +79,8 @@ async def test_protocol_read_only_transport_error() -> None:
 
     assert getattr(protocol, "_transport", None) is transport
 
-    with pytest.raises(RuntimeError, match="does not support writing"):
-        protocol.write(b"TEST\n")
+    with pytest.raises(AttributeError, match="object has no attribute 'write'"):
+        await protocol.write(b"TEST\n")
 
     transport.close()
 
@@ -102,16 +92,6 @@ async def test_protocol_connected_check_on_start_tls(
 
     with pytest.raises(SMTPServerDisconnected):
         await smtp_protocol.start_tls(client_tls_context, timeout=1.0)
-
-
-async def test_protocol_already_over_tls_check_on_start_tls(
-    client_tls_context: ssl.SSLContext,
-) -> None:
-    smtp_protocol = SMTPProtocol()
-    smtp_protocol._over_ssl = True
-
-    with pytest.raises(RuntimeError, match="Already using TLS"):
-        await smtp_protocol.start_tls(client_tls_context)
 
 
 async def test_protocol_connection_reset_on_starttls(
@@ -133,30 +113,6 @@ async def test_protocol_connection_reset_on_starttls(
     monkeypatch.setattr(event_loop, "start_tls", mock_start_tls)
 
     with pytest.raises(SMTPServerDisconnected):
-        await protocol.start_tls(client_tls_context)
-
-    transport.close()
-
-
-async def test_protocol_timeout_on_starttls(
-    hostname: str,
-    smtpd_server_port: int,
-    client_tls_context: ssl.SSLContext,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    event_loop = asyncio.get_running_loop()
-
-    connect_future = event_loop.create_connection(
-        SMTPProtocol, host=hostname, port=smtpd_server_port
-    )
-    transport, protocol = await asyncio.wait_for(connect_future, timeout=1.0)
-
-    def mock_start_tls(*args, **kwargs) -> None:
-        raise TimeoutError("Timed out")
-
-    monkeypatch.setattr(event_loop, "start_tls", mock_start_tls)
-
-    with pytest.raises(SMTPTimeoutError, match="Timed out while upgrading transport"):
         await protocol.start_tls(client_tls_context)
 
     transport.close()
@@ -226,40 +182,6 @@ async def test_protocol_error_on_readline_with_malformed_response(
     await cleanup_server(server)
 
 
-async def test_protocol_response_waiter_unset(
-    bind_address: str,
-    hostname: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    event_loop = asyncio.get_running_loop()
-
-    async def client_connected(
-        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
-    ) -> None:
-        await reader.read(1000)
-        writer.write(b"220 Hi\r\n")
-        await writer.drain()
-
-    server = await asyncio.start_server(
-        client_connected, host=bind_address, port=0, family=socket.AF_INET
-    )
-    server_port = server.sockets[0].getsockname()[1] if server.sockets else 0
-
-    connect_future = event_loop.create_connection(
-        SMTPProtocol, host=hostname, port=server_port
-    )
-
-    _, protocol = await asyncio.wait_for(connect_future, timeout=1.0)
-
-    monkeypatch.setattr(protocol, "_response_waiter", None)
-
-    with pytest.raises(SMTPServerDisconnected):
-        await protocol.execute_command(b"TEST\n", timeout=1.0)  # type: ignore
-
-    server.close()
-    await cleanup_server(server)
-
-
 async def test_protocol_data_received_called_twice(
     bind_address: str,
     hostname: str,
@@ -287,7 +209,7 @@ async def test_protocol_data_received_called_twice(
 
     _, protocol = await asyncio.wait_for(connect_future, timeout=1.0)
 
-    response = await protocol.execute_command(b"TEST\n", timeout=1.0)  # type: ignore
+    response = await protocol.execute_command(b"TEST\n")
 
     assert response.code == 220
     assert response.message == "Hi"
@@ -347,8 +269,8 @@ async def test_protocol_exception_cleanup_warning(
     )
     _, protocol = await asyncio.wait_for(connect_future, timeout=1.0)
 
-    await protocol.execute_command(b"HELO\n", timeout=1.0)
-    await protocol.execute_command(b"QUIT\n", timeout=1.0)
+    await protocol.execute_command(b"HELO\n")
+    await protocol.execute_command(b"QUIT\n")
 
     del protocol
     # Force garbage collection

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -17,10 +17,13 @@ from aiosmtplib import (
 from aiosmtplib.protocol import SMTPProtocol
 
 from .compat import cleanup_server
-from .smtpd import mock_response_delayed_ok, mock_response_delayed_read
+from .smtpd import (
+    mock_response_delayed_ok_with_cleanup,
+    mock_response_delayed_read_with_cleanup,
+)
 
 
-@pytest.mark.smtpd_mocks(smtp_EHLO=mock_response_delayed_ok)
+@pytest.mark.smtpd_mocks(smtp_EHLO=mock_response_delayed_ok_with_cleanup)
 async def test_command_timeout_error(smtp_client: SMTP) -> None:
     await smtp_client.connect()
 
@@ -28,7 +31,7 @@ async def test_command_timeout_error(smtp_client: SMTP) -> None:
         await smtp_client.ehlo(hostname="example.com", timeout=0.0)
 
 
-@pytest.mark.smtpd_mocks(smtp_DATA=mock_response_delayed_ok)
+@pytest.mark.smtpd_mocks(smtp_DATA=mock_response_delayed_ok_with_cleanup)
 async def test_data_timeout_error(smtp_client: SMTP) -> None:
     await smtp_client.connect()
     await smtp_client.ehlo()
@@ -38,50 +41,28 @@ async def test_data_timeout_error(smtp_client: SMTP) -> None:
         await smtp_client.data("HELLO WORLD", timeout=0.0)
 
 
-@pytest.mark.smtpd_mocks(_handle_client=mock_response_delayed_ok)
+@pytest.mark.smtpd_mocks(_handle_client=mock_response_delayed_ok_with_cleanup)
 async def test_timeout_error_on_connect(smtp_client: SMTP) -> None:
     with pytest.raises(SMTPTimeoutError):
         await smtp_client.connect(timeout=0.0)
 
-    assert smtp_client.transport is None
     assert smtp_client.protocol is None
 
 
-@pytest.mark.smtpd_mocks(_handle_client=mock_response_delayed_read)
+@pytest.mark.smtpd_mocks(_handle_client=mock_response_delayed_read_with_cleanup)
 async def test_timeout_on_initial_read(smtp_client: SMTP) -> None:
     with pytest.raises(SMTPTimeoutError):
         # We need to use a timeout > 0 here to avoid timing out on connect
         await smtp_client.connect(timeout=0.01)
 
 
-@pytest.mark.smtpd_mocks(smtp_STARTTLS=mock_response_delayed_ok)
+@pytest.mark.smtpd_mocks(smtp_STARTTLS=mock_response_delayed_ok_with_cleanup)
 async def test_timeout_on_starttls(smtp_client: SMTP) -> None:
     await smtp_client.connect()
     await smtp_client.ehlo()
 
     with pytest.raises(SMTPTimeoutError):
         await smtp_client.starttls(timeout=0.0)
-
-
-async def test_protocol_read_response_with_timeout_times_out(
-    echo_server: asyncio.AbstractServer,
-    hostname: str,
-    echo_server_port: int,
-) -> None:
-    event_loop = asyncio.get_running_loop()
-
-    connect_future = event_loop.create_connection(
-        SMTPProtocol, host=hostname, port=echo_server_port
-    )
-
-    transport, protocol = await asyncio.wait_for(connect_future, timeout=1.0)
-
-    with pytest.raises(SMTPTimeoutError) as exc:
-        await protocol.read_response(timeout=0.0)  # type: ignore
-
-    transport.close()
-
-    assert str(exc.value) == "Timed out waiting for server response"
 
 
 async def test_connect_timeout_error(hostname: str, unused_tcp_port: int) -> None:

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -3,7 +3,6 @@ Timeout tests.
 """
 
 import asyncio
-import socket
 import ssl
 
 import pytest
@@ -16,7 +15,6 @@ from aiosmtplib import (
 )
 from aiosmtplib.protocol import SMTPProtocol
 
-from .compat import cleanup_server
 from .smtpd import (
     mock_response_delayed_ok_with_cleanup,
     mock_response_delayed_read_with_cleanup,
@@ -89,37 +87,6 @@ async def test_server_disconnected_error_after_connect_timeout(
 
     with pytest.raises(SMTPServerDisconnected):
         await client.sendmail(sender_str, [recipient_str], message_str)
-
-
-async def test_protocol_timeout_on_starttls(
-    bind_address: str,
-    hostname: str,
-    client_tls_context: ssl.SSLContext,
-) -> None:
-    event_loop = asyncio.get_running_loop()
-
-    async def client_connected(
-        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
-    ) -> None:
-        await asyncio.sleep(1.0)
-
-    server = await asyncio.start_server(
-        client_connected, host=bind_address, port=0, family=socket.AF_INET
-    )
-    server_port = server.sockets[0].getsockname()[1] if server.sockets else 0
-
-    connect_future = event_loop.create_connection(
-        SMTPProtocol, host=hostname, port=server_port
-    )
-
-    _, protocol = await asyncio.wait_for(connect_future, timeout=1.0)
-
-    with pytest.raises(SMTPTimeoutError):
-        # STARTTLS timeout must be > 0
-        await protocol.start_tls(client_tls_context, timeout=0.00001)  # type: ignore
-
-    server.close()
-    await cleanup_server(server)
 
 
 async def test_protocol_connection_aborted_on_starttls(

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -48,9 +48,7 @@ async def test_starttls(smtp_client: SMTP) -> None:
         assert not smtp_client.supported_auth_methods
         assert not smtp_client.supports_esmtp
 
-        # Make sure our connection was actually upgraded. ssl protocol transport is
-        # private in UVloop, so just check the class name.
-        assert "SSL" in type(smtp_client.transport).__name__
+        assert smtp_client.get_transport_info("sslcontext") is not None
 
         response = await smtp_client.ehlo()
         assert response.code == SMTPStatus.completed
@@ -68,18 +66,14 @@ async def test_starttls_init_kwarg(
     )
 
     async with smtp_client:
-        # Make sure our connection was actually upgraded. ssl protocol transport is
-        # private in UVloop, so just check the class name.
-        assert "SSL" in type(smtp_client.transport).__name__
+        assert smtp_client.get_transport_info("sslcontext") is not None
 
 
 @pytest.mark.smtpd_options(tls=False)
 async def test_starttls_connect_kwarg(smtp_client: SMTP) -> None:
     await smtp_client.connect(start_tls=True)
 
-    # Make sure our connection was actually upgraded. ssl protocol transport is
-    # private in UVloop, so just check the class name.
-    assert "SSL" in type(smtp_client.transport).__name__
+    assert smtp_client.get_transport_info("sslcontext") is not None
 
     await smtp_client.quit()
 
@@ -96,9 +90,7 @@ async def test_starttls_auto(
     )
 
     async with smtp_client:
-        # Make sure our connection was actually upgraded. ssl protocol transport is
-        # private in UVloop, so just check the class name.
-        assert "SSL" in type(smtp_client.transport).__name__
+        assert smtp_client.get_transport_info("sslcontext") is not None
 
 
 async def test_starttls_auto_connect_kwarg(
@@ -116,9 +108,7 @@ async def test_starttls_auto_connect_kwarg(
 
     await smtp_client.connect(start_tls=None)
 
-    # Make sure our connection was actually upgraded. ssl protocol transport is
-    # private in UVloop, so just check the class name.
-    assert "SSL" in type(smtp_client.transport).__name__
+    assert smtp_client.get_transport_info("sslcontext") is not None
 
     await smtp_client.quit()
 
@@ -130,9 +120,7 @@ async def test_starttls_auto_connect_not_supported(smtp_client: SMTP) -> None:
     async with smtp_client:
         await smtp_client.ehlo()
 
-        # Make sure our connection was nul upgraded. ssl protocol transport is
-        # private in UVloop, so just check the class name.
-        assert "SSL" not in type(smtp_client.transport).__name__
+        assert smtp_client.get_transport_info("sslcontext") is None
 
 
 @pytest.mark.smtpd_options(tls=False)
@@ -190,9 +178,7 @@ async def test_starttls_invalid_responses(smtp_client: SMTP) -> None:
         assert smtp_client.esmtp_extensions == old_extensions
         assert smtp_client.supports_esmtp is True
 
-        # Make sure our connection was not upgraded. ssl protocol transport is
-        # private in UVloop, so just check the class name.
-        assert "SSL" not in type(smtp_client.transport).__name__
+        assert smtp_client.get_transport_info("sslcontext") is None
 
 
 @pytest.mark.smtpd_options(tls=False)


### PR DESCRIPTION
- Updates protocol methods to follow stdlib stream implementations (at least somewhat)
- Removes transport usage on `SMTP` class
- Adds `SMTP.wait_closed`