### PR TITLE
fix: correct aexit signature to comply with async context manager protocol

### DIFF
--- a/src/aiosmtplib/smtp.py
+++ b/src/aiosmtplib/smtp.py
@@ -9,6 +9,7 @@ import email.message
 import socket
 import ssl
 from collections.abc import Iterable, Sequence
+from types import TracebackType
 from typing import (
     Any,
     Literal,
@@ -182,7 +183,7 @@ class SMTP:
         self,
         exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
-        traceback: Any,
+        traceback: Optional[TracebackType],
     ) -> None:
         if isinstance(exc, (ConnectionError, TimeoutError)):
             self.close()


### PR DESCRIPTION
The [official typeshed protocol/abc](https://github.com/python/typeshed/blob/8a56044cd6c4a6dd3e41cc9b37e798da5a9446fe/stdlib/contextlib.pyi#L60-L65) annotate `exc_type` and `ext_value` as optional. 

This PR updates the `SMTP.__aexit__(...)` signature to comply.

~Note: I've left the `traceback` annotated as `Any`, but `types.TracebackType` is available in the stdlib and the correct annotation would be `traceback: Optional[TracebackType]`~ fixed as requested in [this comment](https://github.com/cole/aiosmtplib/pull/323?notification_referrer_id=NT_kwDOAXQnDLQxODMzODMzMzM1NToyNDM4OTM4OA#issuecomment-3204249919)

---

(fyi, I found this by running astral's [ty](https://github.com/astral-sh/ty) instead of pyright)