### PR TITLE
chore: port to pytest-asyncio 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ path = "src/aiosmtplib/__init__.py"
 [tool.pytest.ini_options]
 pythonpath = "src"
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "session"
+asyncio_default_fixture_loop_scope = "function"
 minversion = "6.0"
 junit_family = "xunit2"
 addopts = ["--import-mode=importlib", "--strict-markers"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest>=7.2
-pytest-asyncio>=0.20.1,<1.0.0
+pytest-asyncio>=0.20.1
 pytest-cov>=4.0
 pytest-xdist>=3.0
 coverage[toml]>=6.5

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -414,9 +414,9 @@ async def test_flow_control_mixin_drain_incomplete():
     assert not waiter.cancelled()
 
 
-def test_flow_control_mixin_connection_lost_exception(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_flow_control_mixin_connection_lost_exception() -> None:
+    event_loop = asyncio.get_running_loop()
+
     flow_control = FlowControlMixin(event_loop)
     flow_control.pause_writing()
     waiter = event_loop.create_future()
@@ -431,9 +431,9 @@ def test_flow_control_mixin_connection_lost_exception(
     assert waiter.exception() is exc
 
 
-def test_flow_control_mixin_connection_lost_no_exception(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_flow_control_mixin_connection_lost_no_exception() -> None:
+    event_loop = asyncio.get_running_loop()
+
     flow_control = FlowControlMixin(event_loop)
     flow_control.pause_writing()
     waiter = event_loop.create_future()
@@ -447,9 +447,9 @@ def test_flow_control_mixin_connection_lost_no_exception(
     assert waiter.exception() is None
 
 
-def test_flow_control_mixin_connection_lost_done(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_flow_control_mixin_connection_lost_done() -> None:
+    event_loop = asyncio.get_running_loop()
+
     flow_control = FlowControlMixin(event_loop)
     flow_control.pause_writing()
     waiter = event_loop.create_future()


### PR DESCRIPTION
This mostly follows
https://pytest-asyncio.readthedocs.io/en/stable/how-to-guides/migrate_from_0_21.html; I had to weaken one test a bit to avoid running into problems with pytest-asyncio's finalizer code.