### PR TITLE
Fix SMTP.quit() hang when transport is lost with exception after QUIT

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Bugfix: ``SMTP.quit()`` no longer hangs until the read timeout when the
+  peer drops the transport with an exception after ``QUIT`` is sent but
+  before the 221 reply is parsed (e.g. AWS SES closing TLS without
+  ``close_notify``).
+
+
 5.1.0
 -----
 

--- a/src/aiosmtplib/protocol.py
+++ b/src/aiosmtplib/protocol.py
@@ -132,12 +132,15 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
     def connection_lost(self, exc: Exception | None) -> None:
         super().connection_lost(exc)
 
-        if not self._quit_sent:
-            smtp_exc = SMTPServerDisconnected("Connection lost")
-            if exc:
-                smtp_exc.__cause__ = exc
-
-            if self._response_waiter and not self._response_waiter.done():
+        if self._response_waiter and not self._response_waiter.done():
+            if self._quit_sent:
+                self._response_waiter.set_result(
+                    SMTPResponse(SMTPStatus.closing.value, "")
+                )
+            else:
+                smtp_exc = SMTPServerDisconnected("Connection lost")
+                if exc:
+                    smtp_exc.__cause__ = exc
                 self._response_waiter.set_exception(smtp_exc)
 
         self.transport = None

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -480,3 +480,60 @@ async def test_flow_control_mixin_drain_helper_connection_lost() -> None:
 
     with pytest.raises(ConnectionResetError):
         await flow_control._drain_helper()
+
+
+class _FakeTransport(asyncio.Transport):
+    """Minimal transport stub for driving SMTPProtocol callbacks directly."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._extra: dict[str, object] = {"sslcontext": object()}
+
+    def get_extra_info(self, name: str, default: object = None) -> object:
+        return self._extra.get(name, default)
+
+    def is_closing(self) -> bool:
+        return False
+
+
+async def test_protocol_connection_lost_after_quit_resolves_waiter() -> None:
+    """
+    Regression test for https://github.com/cole/aiosmtplib/issues/345.
+
+    When the peer drops the transport with an exception after ``QUIT\\r\\n``
+    has been written but before the 221 reply is parsed (e.g. AWS SES closes
+    TLS without ``close_notify``, surfaced as ``connection_lost(SSLEOFError)``),
+    the response waiter must be resolved so that ``SMTP.quit()`` returns
+    promptly instead of blocking until the read timeout.
+    """
+    protocol = SMTPProtocol()
+    protocol.connection_made(_FakeTransport())
+
+    protocol._quit_sent = True
+    waiter = protocol._response_waiter
+    assert waiter is not None and not waiter.done()
+
+    protocol.connection_lost(ssl.SSLEOFError("EOF occurred in violation of protocol"))
+
+    assert waiter.done()
+    assert waiter.exception() is None
+    response = waiter.result()
+    assert response.code == 221
+
+
+async def test_protocol_connection_lost_without_quit_raises() -> None:
+    """
+    Without an outstanding QUIT, ``connection_lost`` must continue to
+    surface ``SMTPServerDisconnected`` on the response waiter.
+    """
+    protocol = SMTPProtocol()
+    protocol.connection_made(_FakeTransport())
+
+    waiter = protocol._response_waiter
+    assert waiter is not None and not waiter.done()
+
+    protocol.connection_lost(ConnectionResetError("boom"))
+
+    assert waiter.done()
+    exc = waiter.exception()
+    assert isinstance(exc, SMTPServerDisconnected)


### PR DESCRIPTION
Closes #345.

## Summary

`SMTP.quit()` previously blocked until its read timeout (default 60 s) when
the peer dropped the underlying transport with an exception after `QUIT\r\n`
had been written but before the `221` reply was parsed.

The most reproducible case is the AWS SES SMTP endpoint
(`email-smtp.<region>.amazonaws.com:587`), which closes the TLS connection
without sending `close_notify`. Python's `ssl` surfaces this to `asyncio` as
`connection_lost(ssl.SSLEOFError(...))` and discards the buffered `221 Bye`
line as a protocol violation, leaving `SMTPProtocol._response_waiter`
pending forever.

See #345 for the full root-cause write-up and a minimal repro that drives
`SMTPProtocol.connection_lost()` directly without any network or TLS setup.

## Fix

`SMTPProtocol.connection_lost` now always completes `_response_waiter` if it
is still pending:

- If `_quit_sent` is set, the waiter resolves with a synthetic
  `SMTPResponse(221, "")` — the close is treated as a graceful QUIT, so
  `SMTP.quit()` returns success rather than hanging.
- Otherwise the existing behaviour is preserved: the waiter is resolved
  with `SMTPServerDisconnected("Connection lost")` (chained to the original
  exception, when present).

This is option **(a)** from the issue.

## Tests

Two new unit tests in `tests/test_protocol.py`, both driving
`SMTPProtocol.connection_lost()` directly via a minimal `asyncio.Transport`
stub (no network or TLS required):

- `test_protocol_connection_lost_after_quit_resolves_waiter`
  Regression test for #345 — simulates the post-`QUIT` `SSLEOFError` path
  and asserts the response waiter resolves with code `221`.
- `test_protocol_connection_lost_without_quit_raises`
  Pins existing behaviour — without an outstanding `QUIT`, `connection_lost`
  still surfaces `SMTPServerDisconnected` on the waiter.

Full local verification:

- `pytest` — 334 passed
- `ruff check` / `ruff format --check` — clean
- `mypy src/aiosmtplib` — clean
- `pyright src/aiosmtplib` — 0 errors
- `ty check src/aiosmtplib` — clean
- `pre-commit run --all-files` — all hooks pass

## Backward compatibility

Behaviour only changes on the post-`QUIT` connection-lost path, which
previously left `_response_waiter` pending and ultimately caused
`SMTPReadTimeoutError` (after the read timeout). Callers that relied on the
old hang/timeout would already have been treating QUIT as best-effort.

## Changelog

Added an `Unreleased` entry to `CHANGELOG.rst` describing the bugfix.