### PR TITLE
fix: prevent SMTP command/response desync from unsolicited server data

### DIFF
--- a/src/aiosmtplib/protocol.py
+++ b/src/aiosmtplib/protocol.py
@@ -106,6 +106,11 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
         self._over_ssl = False
         self._buffer = bytearray()
         self._response_waiter: asyncio.Future[SMTPResponse] | None = None
+        # True only while a command is actually awaiting a response. Used to
+        # discard unsolicited data that arrives between commands, which would
+        # otherwise be stored on the (freshly created) waiter and mis-paired
+        # with the next command's response.
+        self._response_pending = False
 
         self.transport: asyncio.BaseTransport | None = None
         self._command_lock: asyncio.Lock | None = None
@@ -134,6 +139,9 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
         self._response_waiter = self._loop.create_future()
         self._command_lock = asyncio.Lock()
         self._quit_sent = False
+        # The server's greeting is expected immediately after connecting, and
+        # may arrive before read_response() is awaited, so arm the flag now.
+        self._response_pending = True
 
     def connection_lost(self, exc: Exception | None) -> None:
         super().connection_lost(exc)
@@ -160,8 +168,10 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
             raise RuntimeError(
                 f"data_received called without a response waiter set: {data!r}"
             )
-        elif self._response_waiter.done():
-            # We got a response without issuing a command; ignore it.
+        elif not self._response_pending or self._response_waiter.done():
+            # We got data without an outstanding command (or a response is
+            # already parsed and awaiting pickup); ignore it so it can't be
+            # mis-paired with a later command's response.
             return
 
         self._buffer.extend(data)
@@ -274,11 +284,15 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
         if self._response_waiter is None:
             raise SMTPServerDisconnected("Connection lost")
 
+        # Safety net: guarantees the flag is set for reads not preceded by a
+        # command write (e.g. the initial server greeting).
+        self._response_pending = True
         try:
             result = await asyncio.wait_for(self._response_waiter, timeout)
         except (TimeoutError, asyncio.TimeoutError) as exc:
             raise SMTPReadTimeoutError("Timed out waiting for server response") from exc
         finally:
+            self._response_pending = False
             # If we were disconnected, don't create a new waiter
             if self.transport is None:
                 self._response_waiter = None
@@ -314,6 +328,9 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
         command = b" ".join(args) + b"\r\n"
 
         async with self._command_lock:
+            # Mark a reply as expected before sending, so data arriving after
+            # the write can never be mistaken for unsolicited data.
+            self._response_pending = True
             self.write(command)
 
             if command == b"QUIT\r\n":
@@ -343,11 +360,14 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
         message += b".\r\n"
 
         async with self._command_lock:
+            # Mark a reply as expected before each send (see execute_command).
+            self._response_pending = True
             self.write(b"DATA\r\n")
             start_response = await self.read_response(timeout=timeout)
             if start_response.code != SMTPStatus.start_input:
                 raise SMTPDataError(start_response.code, start_response.message)
 
+            self._response_pending = True
             self.write(message)
             response = await self.read_response(timeout=timeout)
             if response.code != SMTPStatus.completed:
@@ -370,6 +390,8 @@ class SMTPProtocol(FlowControlMixin, asyncio.BaseProtocol):
             raise SMTPServerDisconnected("Server not connected")
 
         async with self._command_lock:
+            # Mark a reply as expected before sending (see execute_command).
+            self._response_pending = True
             self.write(b"STARTTLS\r\n")
             response = await self.read_response(timeout=timeout)
             if response.code != SMTPStatus.ready:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -657,3 +657,90 @@ async def test_protocol_execute_command_rejects_injected_option() -> None:
         )
 
     assert transport.writes == []
+
+
+async def test_protocol_ignores_unsolicited_data_between_commands() -> None:
+    """
+    Data received while no command is outstanding must be discarded, not stored
+    on the next waiter. Otherwise a single unsolicited line permanently desyncs
+    every subsequent command/response pair by one.
+    """
+    protocol = SMTPProtocol()
+    transport = _WriteRecordingTransport()
+    protocol.connection_made(transport)
+
+    # Greeting, consumed by a normal read.
+    protocol.data_received(b"220 hi\r\n")
+    greeting = await protocol.read_response(timeout=1.0)
+    assert greeting.code == 220
+
+    # An unsolicited line arrives while the client is idle between commands.
+    protocol.data_received(b"250 unsolicited\r\n")
+    assert protocol._response_waiter is not None
+    assert not protocol._response_waiter.done()
+    assert protocol._buffer == bytearray()
+
+    # The next command must receive its OWN response, not the stale line.
+    task = asyncio.ensure_future(protocol.execute_command(b"NOOP", timeout=1.0))
+    await asyncio.sleep(0)  # let the command write and start awaiting
+    protocol.data_received(b"250 real noop reply\r\n")
+
+    response = await task
+    assert response.code == 250
+    assert response.message == "real noop reply"
+
+
+async def test_protocol_ignores_unsolicited_multiline_data() -> None:
+    """An unsolicited multiline response between commands must be discarded."""
+    protocol = SMTPProtocol()
+    transport = _WriteRecordingTransport()
+    protocol.connection_made(transport)
+
+    protocol.data_received(b"220 hi\r\n")
+    greeting = await protocol.read_response(timeout=1.0)
+    assert greeting.code == 220
+
+    # A full multiline response arrives while no command is outstanding.
+    protocol.data_received(b"250-foo\r\n250-bar\r\n250 baz\r\n")
+    assert protocol._response_waiter is not None
+    assert not protocol._response_waiter.done()
+    assert protocol._buffer == bytearray()
+
+    task = asyncio.ensure_future(protocol.execute_command(b"NOOP", timeout=1.0))
+    await asyncio.sleep(0)
+    protocol.data_received(b"250 real\r\n")
+
+    response = await task
+    assert response.code == 250
+    assert response.message == "real"
+
+
+async def test_protocol_ignores_unsolicited_partial_data() -> None:
+    """
+    Unsolicited data fragmented across data_received calls between commands
+    must be discarded, not buffered for the next command.
+    """
+    protocol = SMTPProtocol()
+    transport = _WriteRecordingTransport()
+    protocol.connection_made(transport)
+
+    protocol.data_received(b"220 hi\r\n")
+    greeting = await protocol.read_response(timeout=1.0)
+    assert greeting.code == 220
+
+    # Unsolicited response trickling in across multiple chunks, including a
+    # mid-line split, while no command is outstanding.
+    protocol.data_received(b"250-foo\r\n")
+    protocol.data_received(b"250 ba")
+    protocol.data_received(b"r\r\n")
+    assert protocol._response_waiter is not None
+    assert not protocol._response_waiter.done()
+    assert protocol._buffer == bytearray()
+
+    task = asyncio.ensure_future(protocol.execute_command(b"NOOP", timeout=1.0))
+    await asyncio.sleep(0)
+    protocol.data_received(b"250 real\r\n")
+
+    response = await task
+    assert response.code == 250
+    assert response.message == "real"


### PR DESCRIPTION
﻿Hello,

While reviewing connection reuse and pooling behaviors, we identified a critical edge case where unsolicited data sent by the SMTP server during idle periods permanently desynchronizes the connection. 

This PR resolves the issue by introducing explicit tracking for when a response is actually pending.

### The Root Cause

Our lower-level `SMTPProtocol.data_received` method has a guard designed to discard incoming data if no command is outstanding:

```python
elif self._response_waiter.done():
    # We got a response without issuing a command; ignore it.
    return
```

The catch is that `read_response()` always cleans up after itself in a `finally` block by immediately instantiating a fresh waiter Future:

```python
finally:
    # ...
    else:
        self._response_waiter = self._loop.create_future()
```

Because this new Future is fresh, `self._response_waiter.done()` returns `False`. If the server sends any data while the client was idle between commands, the guard is bypassed. The protocol processes the data, parses it, and resolves the waiter with the unsolicited response.

The next command sent by the client then immediately receives this stale, unsolicited response. From that point forward, the entire connection is offset by one: every command gets the response of the *previous* command. For an email client, this could lead to silently reporting failed operations as successful (or vice versa).

---

### Step-by-Step Failure Scenario

Here is exactly how the desynchronization happens:

1. **Connection Established:** Client receives the greeting (`220 hi`) and reads it successfully.
2. **Idle Period:** The client is idle. `self._response_waiter` is a fresh, pending Future.
3. **Unsolicited Packet:** The server sends some unsolicited line or a timeout warning (e.g., `250 unsolicited`).
4. **Buffer Pollution:** `data_received` processes this because the waiter isn't "done" yet. The future is resolved with the unsolicited line.
5. **Next Command:** Client executes `NOOP`.
6. **Desync Triggered:** `execute_command` awaits `read_response()`. Because the future is already resolved, it immediately returns `250 unsolicited` instead of the actual `NOOP` reply.
7. **The Shift:** The real `NOOP` response arrives shortly after and is stored on the next waiter. When the client later sends a `MAIL` command, it ends up reading the `NOOP` reply.

```
Client                             Server
  │                                  │
  │ ──── (Idle / Connection Open) ── │
  │                                  │
  │ <─── 250 unsolicited ─────────── │ (Stored on the fresh waiter)
  │                                  │
  │ ──── NOOP ─────────────────────> │
  │                                  │
  │ <─── (Immediate Local Return) ── │ (NOOP returns "250 unsolicited")
  │                                  │
  │ <─── 250 real-noop-reply ─────── │ (Stored on the next waiter)
```

---

### The Solution

We introduced a private boolean flag, `_response_pending`, on the protocol to strictly govern when we care about incoming network data:

* **Initial Greeting:** Armed immediately in `connection_made` because we expect the server's greeting right away.
* **Socket Writes:** Armed right before writing to the transport inside `execute_command`, `execute_data_command`, and `start_tls`. This closes any theoretical reentrancy window where a server might reply instantly before `read_response` is called.
* **Clean-up:** Cleared whenever `read_response` exits (either successfully or via an exception).

`data_received` now safely discards incoming data if `_response_pending` is `False`.

---

### Test Plan

We added three regression tests in `tests/test_protocol.py` to ensure this is fully locked down:

1. `test_protocol_ignores_unsolicited_data_between_commands`: Verifies that a standard single-line unsolicited message is discarded and the next command gets its correct response.
2. `test_protocol_ignores_unsolicited_multiline_data`: Ensures multiline unsolicited sequences (like a multiline EHLO or custom server message) are ignored.
3. `test_protocol_ignores_unsolicited_partial_data`: Tests that fragmented unsolicited packets trickling in across multiple socket reads do not pollute the buffer.

All tests pass perfectly on Python 3.14.