### PR TITLE
Fix blocking I/O operations in the event loop

### DIFF
--- a/src/aiosmtplib/smtp.py
+++ b/src/aiosmtplib/smtp.py
@@ -619,26 +619,24 @@ class SMTP:
         """
         if self.tls_context is not None:
             return self.tls_context
+
+        return await asyncio.to_thread(self._build_tls_context)
+
+    def _build_tls_context(self) -> ssl.SSLContext:
+        # SERVER_AUTH is what we want for a client side socket
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        context.check_hostname = bool(self.validate_certs)
+        if self.validate_certs:
+            context.verify_mode = ssl.CERT_REQUIRED
         else:
-            loop = asyncio.get_event_loop()
+            context.verify_mode = ssl.CERT_NONE
 
-            def _run() -> ssl.SSLContext:
-                # SERVER_AUTH is what we want for a client side socket
-                context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-                context.check_hostname = bool(self.validate_certs)
-                if self.validate_certs:
-                    context.verify_mode = ssl.CERT_REQUIRED
-                else:
-                    context.verify_mode = ssl.CERT_NONE
+        if self.cert_bundle is not None:
+            context.load_verify_locations(cafile=self.cert_bundle)
 
-                if self.cert_bundle is not None:
-                    context.load_verify_locations(cafile=self.cert_bundle)
-
-                if self.client_cert is not None:
-                    context.load_cert_chain(self.client_cert, keyfile=self.client_key)
-                return context
-
-            return await loop.run_in_executor(None, _run)
+        if self.client_cert is not None:
+            context.load_cert_chain(self.client_cert, keyfile=self.client_key)
+        return context
 
     def close(self) -> None:
         """

--- a/src/aiosmtplib/smtp.py
+++ b/src/aiosmtplib/smtp.py
@@ -480,7 +480,7 @@ class SMTP:
         ssl_handshake_timeout: float | None = None
         server_hostname: str | None = None
         if self.use_tls:
-            tls_context = self._get_tls_context()
+            tls_context = await self._get_tls_context()
             ssl_handshake_timeout = timeout
             server_hostname = self.hostname
 
@@ -613,28 +613,32 @@ class SMTP:
 
         return response
 
-    def _get_tls_context(self) -> ssl.SSLContext:
+    async def _get_tls_context(self) -> ssl.SSLContext:
         """
         Build an SSLContext object from the options we've been given.
         """
         if self.tls_context is not None:
-            context = self.tls_context
+            return self.tls_context
         else:
-            # SERVER_AUTH is what we want for a client side socket
-            context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-            context.check_hostname = bool(self.validate_certs)
-            if self.validate_certs:
-                context.verify_mode = ssl.CERT_REQUIRED
-            else:
-                context.verify_mode = ssl.CERT_NONE
+            loop = asyncio.get_event_loop()
 
-            if self.cert_bundle is not None:
-                context.load_verify_locations(cafile=self.cert_bundle)
+            def _run() -> ssl.SSLContext:
+                # SERVER_AUTH is what we want for a client side socket
+                context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+                context.check_hostname = bool(self.validate_certs)
+                if self.validate_certs:
+                    context.verify_mode = ssl.CERT_REQUIRED
+                else:
+                    context.verify_mode = ssl.CERT_NONE
 
-            if self.client_cert is not None:
-                context.load_cert_chain(self.client_cert, keyfile=self.client_key)
+                if self.cert_bundle is not None:
+                    context.load_verify_locations(cafile=self.cert_bundle)
 
-        return context
+                if self.client_cert is not None:
+                    context.load_cert_chain(self.client_cert, keyfile=self.client_key)
+                return context
+
+            return await loop.run_in_executor(None, _run)
 
     def close(self) -> None:
         """
@@ -1067,7 +1071,7 @@ class SMTP:
         if timeout is Default.token:
             timeout = self.timeout
 
-        tls_context = self._get_tls_context()
+        tls_context = await self._get_tls_context()
 
         if not self.supports_extension("starttls"):
             raise SMTPException("SMTP STARTTLS extension not supported by server.")


### PR DESCRIPTION
The `_get_tls_context` method performs blocking I/O operations, which can block the event loop. This change fixes the issue by offloading those operations to an executor.