### PR TITLE
fix: expose SMTPRecipientsRefused.message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 5.1.4 (unreleased)
 ------------------
 
+- Bugfix: ``SMTPRecipientsRefused`` now exposes the ``message`` attribute shared
+  by all ``SMTPException`` subclasses
 - Bugfix: resolve the ``SMTPProtocol`` close waiter on connection loss, so
   ``asyncio.StreamWriter.wait_closed()`` on a writer wrapping the protocol no
   longer hangs forever

--- a/src/aiosmtplib/errors.py
+++ b/src/aiosmtplib/errors.py
@@ -133,4 +133,5 @@ class SMTPRecipientsRefused(SMTPException):
 
     def __init__(self, recipients: list[SMTPRecipientRefused], /) -> None:
         self.recipients = recipients
+        self.message = str(recipients)
         self.args = (recipients,)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -125,6 +125,20 @@ def test_raise_smtp_recipients_refused(addresses: list[tuple[int, str, str]]) ->
     assert excinfo.value.recipients == errors
 
 
+@pytest.mark.parametrize("recipient_count", (1, 2))
+def test_smtp_recipients_refused_message(recipient_count: int) -> None:
+    errors = [
+        SMTPRecipientRefused(550, "Mailbox unavailable", f"user{index}@example.com")
+        for index in range(recipient_count)
+    ]
+
+    error = SMTPRecipientsRefused(errors)
+
+    assert error.message == str(errors)
+    assert error.args == (errors,)
+    assert str(error) == str(errors)
+
+
 @given(error_message=text())
 def test_raise_smtp_not_supported(error_message: str) -> None:
     with pytest.raises(SMTPNotSupported) as excinfo:


### PR DESCRIPTION
Fixes #352

## The problem

`SMTPException` sets `self.message` in its `__init__`, and that attribute is part of the contract every handler written against the base class relies on. `SMTPRecipientsRefused` overrides `__init__` and never assigns it:

```python
class SMTPRecipientsRefused(SMTPException):
    def __init__(self, recipients: list[SMTPRecipientRefused], /) -> None:
        self.recipients = recipients
        self.args = (recipients,)
```

So the one generic handler shape people actually write breaks precisely when it is handling a delivery failure:

```python
try:
    await send_message(message)
except SMTPException as exc:
    logger.error("send failed: %s", exc.message)  # AttributeError
```

An `AttributeError` inside the error path is worse than the original bounce: the real failure is lost, and the traceback points at the logging line rather than at the refused recipients.

## The fix

One line — derive the aggregate message from the representation the class already builds:

```python
self.message = str(recipients)
```

**`SMTPException.__init__` is deliberately not called here.** It would set `self.args = (message,)`, replacing the refused-recipient list that existing consumers unpack out of `args`. Assigning `message` directly keeps `recipients`, `args`, and `str()` exactly as they are today while filling in the missing attribute.

Nothing else changes: `args` still carries the list, `str(error)` still renders the same text, and `.recipients` is untouched.

## Tests

`test_smtp_recipients_refused_message` is parametrized over the one- and two-recipient cases and pins `message`, `args`, and `str()` *together*, so a future change to any one of the three can't silently drift from the others.

## Changelog

Entry added under `5.1.4 (unreleased)`.

## Verification

`uvx --from poethepoet poe check` — Ruff, format, mypy, Pyright, ty, Bandit, and the full 441-test pytest suite all pass.

Not covered locally: operating systems other than macOS — left to CI.
